### PR TITLE
Build with noarch: python

### DIFF
--- a/bld.bat
+++ b/bld.bat
@@ -1,4 +1,0 @@
-REM Clone modified version of go-tool which includes support for Powershell
-hg clone http://hg.skepticats.com/go-posh
-cd go-posh
-pip install .

--- a/meta.yaml
+++ b/meta.yaml
@@ -5,7 +5,10 @@ package:
 build:
   # If this is a new build for the same version, increment the build
   # number. If you do not include this key, it defaults to 0.
-  number: 0
+  number: 1 
+  noarch: python
+  # Clone modified version of go-tool which includes support for Powershell
+  script: hg clone http://hg.skepticats.com/go-posh && cd go-posh && python -m pip install --no-deps --ignore-installed .
 
 requirements:
   build:


### PR DESCRIPTION
Not sure if this is the best way to do this, but it works. Note that the package can only be built with miniconda2 because there's no mercurial package for python 3.